### PR TITLE
allow customisation of beginSerial

### DIFF
--- a/src/SparkFun_u-blox_SARA-R5_Arduino_Library.cpp
+++ b/src/SparkFun_u-blox_SARA-R5_Arduino_Library.cpp
@@ -5974,6 +5974,7 @@ void SARA_R5::beginSerial(unsigned long baud)
   delay(100);
   if (_hardSerial != NULL)
   {
+    _hardSerial->end();
     _hardSerial->begin(baud);
   }
 #ifdef SARA_R5_SOFTWARE_SERIAL_ENABLED

--- a/src/SparkFun_u-blox_SARA-R5_Arduino_Library.h
+++ b/src/SparkFun_u-blox_SARA-R5_Arduino_Library.h
@@ -1026,7 +1026,7 @@ private:
   int readAvailable(char *inString);
   char readChar(void);
   int hwAvailable(void);
-  void beginSerial(unsigned long baud);
+  virtual void beginSerial(unsigned long baud);
   void setTimeout(unsigned long timeout);
   bool find(char *target);
 


### PR DESCRIPTION
- make beginSerial virtual so that we can override and assign custom pins and configuration
- end the serial port before new begin to avoid crash on ESP32 when data is received while begin is called. I suspect the CRASH is due to the isr still being active if end is not called while begin is reconfiguring the hardware  