### PR TITLE
Make parser more tolerant to spaces in responses URC 

### DIFF
--- a/src/SparkFun_u-blox_SARA-R5_Arduino_Library.cpp
+++ b/src/SparkFun_u-blox_SARA-R5_Arduino_Library.cpp
@@ -320,7 +320,7 @@ bool SARA_R5::processURCEvent(const char *event)
 {
   { // URC: +UUSORD (Read Socket Data)
     int socket, length;
-    int ret = sscanf(event, "+UUSORD: %d,%d", &socket, &length);
+    int ret = sscanf(event, "+UUSORD:%d,%d", &socket, &length);
     if (ret == 2)
     {
       if (_printDebug == true)
@@ -345,7 +345,7 @@ bool SARA_R5::processURCEvent(const char *event)
   }
   { // URC: +UUSORF (Receive From command (UDP only))
     int socket, length;
-    int ret = sscanf(event, "+UUSORF: %d,%d", &socket, &length);
+    int ret = sscanf(event, "+UUSORF:%d,%d", &socket, &length);
     if (ret == 2)
     {
       if (_printDebug == true)
@@ -365,7 +365,7 @@ bool SARA_R5::processURCEvent(const char *event)
     int localIPstore[4] = {0,0,0,0};
 
     int ret = sscanf(event,
-                     "+UUSOLI: %d,\"%d.%d.%d.%d\",%u,%d,\"%d.%d.%d.%d\",%u",
+                     "+UUSOLI:%d,\"%d.%d.%d.%d\",%u,%d,\"%d.%d.%d.%d\",%u",
                      &socket,
                      &remoteIPstore[0], &remoteIPstore[1], &remoteIPstore[2], &remoteIPstore[3],
                      &port, &listenSocket,
@@ -388,7 +388,7 @@ bool SARA_R5::processURCEvent(const char *event)
   }
   { // URC: +UUSOCL (Close Socket)
     int socket;
-    int ret = sscanf(event, "+UUSOCL: %d", &socket);
+    int ret = sscanf(event, "+UUSOCL:%d", &socket);
     if (ret == 1)
     {
       if (_printDebug == true)
@@ -418,7 +418,7 @@ bool SARA_R5::processURCEvent(const char *event)
 
     // This assumes the ULOC response type is "0" or "1" - as selected by gpsRequest detailed
     scanNum = sscanf(event,
-                      "+UULOC: %d/%d/%d,%d:%d:%d.%d,%d.%[^,],%d.%[^,],%d,%lu,%u,%u,%*s",
+                      "+UULOC:%d/%d/%d,%d:%d:%d.%d,%d.%[^,],%d.%[^,],%d,%lu,%u,%u,%*s",
                       &dateStore[0], &dateStore[1], &clck.date.year,
                       &dateStore[2], &dateStore[3], &dateStore[4], &clck.time.ms,
                       &latH, latL, &lonH, lonL, &alt, &uncertainty,
@@ -502,7 +502,7 @@ bool SARA_R5::processURCEvent(const char *event)
     int scanNum;
     int remoteIPstore[4];
 
-    scanNum = sscanf(event, "+UUPSDA: %d,\"%d.%d.%d.%d\"",
+    scanNum = sscanf(event, "+UUPSDA:%d,\"%d.%d.%d.%d\"",
                       &result, &remoteIPstore[0], &remoteIPstore[1], &remoteIPstore[2], &remoteIPstore[3]);
 
     if (scanNum == 5)
@@ -527,7 +527,7 @@ bool SARA_R5::processURCEvent(const char *event)
     int profile, command, result;
     int scanNum;
 
-    scanNum = sscanf(event, "+UUHTTPCR: %d,%d,%d", &profile, &command, &result);
+    scanNum = sscanf(event, "+UUHTTPCR:%d,%d,%d", &profile, &command, &result);
 
     if (scanNum == 3)
     {
@@ -621,7 +621,7 @@ bool SARA_R5::processURCEvent(const char *event)
   { // URC: +A
     int status = 0;
     unsigned int lac = 0, ci = 0, Act = 0;
-    int scanNum = sscanf(event, "+CREG:  %d,\"%4x\",\"%4x\",%d", &status, &lac, &ci, &Act);
+    int scanNum = sscanf(event, "+CREG:%d,\"%4x\",\"%4x\",%d", &status, &lac, &ci, &Act);
     if (scanNum == 4)
     {
       if (_printDebug == true)
@@ -638,7 +638,7 @@ bool SARA_R5::processURCEvent(const char *event)
   { // URC: +CEREG
     int status = 0;
     unsigned int tac = 0, ci = 0, Act = 0;
-    int scanNum = sscanf(event, "+CEREG: %d,\"%4x\",\"%4x\",%d", &status, &tac, &ci, &Act);
+    int scanNum = sscanf(event, "+CEREG:%d,\"%4x\",\"%4x\",%d", &status, &tac, &ci, &Act);
     if (scanNum == 4)
     {
       if (_printDebug == true)
@@ -1124,7 +1124,7 @@ SARA_R5_error_t SARA_R5::clock(uint8_t *y, uint8_t *mo, uint8_t *d,
   {
     char *searchPtr = strstr(response, "+CCLK:");
     if (searchPtr != NULL)
-      scanNum = sscanf(searchPtr, "+CCLK: \"%d/%d/%d,%d:%d:%d%c%d\"\r\n",
+      scanNum = sscanf(searchPtr, "+CCLK:\"%d/%d/%d,%d:%d:%d%c%d\"\r\n",
                &iy, &imo, &id, &ih, &imin, &is, &tzPlusMinus, &itz);
     if (scanNum == 8)
     {
@@ -1259,7 +1259,7 @@ SARA_R5_error_t SARA_R5::getUtimeMode(SARA_R5_utime_mode_t *mode, SARA_R5_utime_
     int mStore, sStore, scanned = 0;
     char *searchPtr = strstr(response, "+UTIME:");
     if (searchPtr != NULL)
-      scanned = sscanf(searchPtr, "+UTIME: %d,%d\r\n", &mStore, &sStore);
+      scanned = sscanf(searchPtr, "+UTIME:%d,%d\r\n", &mStore, &sStore);
     m = (SARA_R5_utime_mode_t)mStore;
     s = (SARA_R5_utime_sensor_t)sStore;
     if (scanned == 2)
@@ -1326,7 +1326,7 @@ SARA_R5_error_t SARA_R5::getUtimeIndication(SARA_R5_utime_urc_configuration_t *c
     int cStore, scanned = 0;
     char *searchPtr = strstr(response, "+UTIMEIND:");
     if (searchPtr != NULL)
-      scanned = sscanf(searchPtr, "+UTIMEIND: %d\r\n", &cStore);
+      scanned = sscanf(searchPtr, "+UTIMEIND:%d\r\n", &cStore);
     c = (SARA_R5_utime_urc_configuration_t)cStore;
     if (scanned == 1)
     {
@@ -1392,9 +1392,9 @@ SARA_R5_error_t SARA_R5::getUtimeConfiguration(int32_t *offsetNanoseconds, int32
     char *searchPtr = strstr(response, "+UTIMECFG:");
     if (searchPtr != NULL)
 #if defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_ESP8266)
-      scanned = sscanf(searchPtr, "+UTIMECFG: %d,%d\r\n", &ons, &os);
+      scanned = sscanf(searchPtr, "+UTIMECFG:%d,%d\r\n", &ons, &os);
 #else
-      scanned = sscanf(searchPtr, "+UTIMECFG: %ld,%ld\r\n", &ons, &os);
+      scanned = sscanf(searchPtr, "+UTIMECFG:%ld,%ld\r\n", &ons, &os);
 #endif
     if (scanned == 2)
     {
@@ -1458,7 +1458,7 @@ int8_t SARA_R5::rssi(void)
   int scanned = 0;
   char *searchPtr = strstr(response, "+CSQ:");
   if (searchPtr != NULL)
-    scanned = sscanf(searchPtr, "+CSQ: %d,%*d", &rssi);
+    scanned = sscanf(searchPtr, "+CSQ:%d,%*d", &rssi);
   if (scanned != 1)
   {
     rssi = -1;
@@ -1502,7 +1502,7 @@ SARA_R5_registration_status_t SARA_R5::registration(bool eps)
   const char *startTag = eps ? "+CEREG:" : "+CREG:";
   char *searchPtr = strstr(response, startTag);
   if (searchPtr != NULL) {
-	  const char *format = eps ? "+CEREG: %*d,%d" : "+CREG: %*d,%d";
+	  const char *format = eps ? "+CEREG:%*d,%d" : "+CREG:%*d,%d";
 	  scanned = sscanf(searchPtr, format, &status);
   }
   if (scanned != 1)
@@ -1668,7 +1668,7 @@ SARA_R5_error_t SARA_R5::getAPN(int cid, String *apn, IPAddress *ip, SARA_R5_pdp
         char strApn[128];
         int ipOct[4];
 		
-        searchPtr += strlen("+CGDCONT:"); // Point to the cid
+        searchPtr += 6; // Point to the cid
         scanned = sscanf(searchPtr, "%d,\"%[^\"]\",\"%[^\"]\",\"%d.%d.%d.%d",
         &rcid, strPdpType, strApn,
 				&ipOct[0], &ipOct[1], &ipOct[2], &ipOct[3]);
@@ -1687,13 +1687,13 @@ SARA_R5_error_t SARA_R5::getAPN(int cid, String *apn, IPAddress *ip, SARA_R5_pdp
           keepGoing = false;
         }
       }
-	  else // We don't have a match so let's clear the APN and IP address
+      else // We don't have a match so let's clear the APN and IP address
       {
-	    if (apn) *apn = "";
-		if (pdpType) *pdpType = PDP_TYPE_INVALID;
-		if (ip) *ip = {0, 0, 0, 0};
-		keepGoing = false;
-	  }  
+        if (apn) *apn = "";
+        if (pdpType) *pdpType = PDP_TYPE_INVALID;
+        if (ip) *ip = {0, 0, 0, 0};
+        keepGoing = false;
+      }  
     }
   }
   else
@@ -1731,7 +1731,7 @@ SARA_R5_error_t SARA_R5::getSimStatus(String* code)
     char c[16];
     char *searchPtr = strstr(response, "+CPIN:");
     if (searchPtr != NULL)
-      scanned = sscanf(searchPtr, "+CPIN: %s\r\n", c);
+      scanned = sscanf(searchPtr, "+CPIN:%s\r\n", c);
     if (scanned == 1)
     {
       if(code)
@@ -1805,7 +1805,7 @@ SARA_R5_error_t SARA_R5::getSIMstateReportingMode(int *mode)
     int scanned = 0;
     char *searchPtr = strstr(response, "+USIMSTAT:");
     if (searchPtr != NULL)
-      scanned = sscanf(searchPtr, "+USIMSTAT: %d\r\n", &m);
+      scanned = sscanf(searchPtr, "+USIMSTAT:%d\r\n", &m);
     if (scanned == 1)
     {
       *mode = m;
@@ -2160,7 +2160,7 @@ SARA_R5_error_t SARA_R5::getPreferredMessageStorage(int *used, int *total, Strin
   int scanned = 0;
   char *searchPtr = strstr(response, "+CPMS:");
   if (searchPtr != NULL)
-    scanned = sscanf(searchPtr, "+CPMS: %d,%d", &u, &t);
+    scanned = sscanf(searchPtr, "+CPMS:%d,%d", &u, &t);
   if (scanned == 2)
   {
     if (_printDebug == true)
@@ -2485,7 +2485,7 @@ int SARA_R5::socketOpen(SARA_R5_socket_protocol_t protocol, unsigned int localPo
     return -1;
   }
 
-  sscanf(responseStart, "+USOCR: %d", &sockId);
+  sscanf(responseStart, "+USOCR:%d", &sockId);
   _lastSocketProtocol[sockId] = (int)protocol;
 
   free(command);
@@ -2763,7 +2763,7 @@ SARA_R5_error_t SARA_R5::socketRead(int socket, int length, char *readDest, int 
     // Extract the data
     char *searchPtr = strstr(response, "+USORD:");
     if (searchPtr != NULL)
-      scanNum = sscanf(searchPtr, "+USORD: %d,%d",
+      scanNum = sscanf(searchPtr, "+USORD:%d,%d",
                         &socketStore, &readLength);
     if (scanNum != 2)
     {
@@ -2876,7 +2876,7 @@ SARA_R5_error_t SARA_R5::socketReadAvailable(int socket, int *length)
   {
     char *searchPtr = strstr(response, "+USORD:");
     if (searchPtr != NULL)
-      scanNum = sscanf(searchPtr, "+USORD: %d,%d",
+      scanNum = sscanf(searchPtr, "+USORD:%d,%d",
                         &socketStore, &readLength);
     if (scanNum != 2)
     {
@@ -2973,7 +2973,7 @@ SARA_R5_error_t SARA_R5::socketReadUDP(int socket, int length, char *readDest,
     // Extract the data
     char *searchPtr = strstr(response, "+USORF:");
     if (searchPtr != NULL)
-      scanNum = sscanf(searchPtr, "+USORF: %d,\"%d.%d.%d.%d\",%d,%d",
+      scanNum = sscanf(searchPtr, "+USORF:%d,\"%d.%d.%d.%d\",%d,%d",
                         &socketStore, &remoteIPstore[0], &remoteIPstore[1], &remoteIPstore[2], &remoteIPstore[3],
                         &portStore, &readLength);
     if (scanNum != 7)
@@ -3106,7 +3106,7 @@ SARA_R5_error_t SARA_R5::socketReadAvailableUDP(int socket, int *length)
   {
     char *searchPtr = strstr(response, "+USORF:");
     if (searchPtr != NULL)
-      scanNum = sscanf(searchPtr, "+USORF: %d,%d",
+      scanNum = sscanf(searchPtr, "+USORF:%d,%d",
                         &socketStore, &readLength);
     if (scanNum != 2)
     {
@@ -3275,7 +3275,7 @@ SARA_R5_error_t SARA_R5::querySocketType(int socket, SARA_R5_socket_protocol_t *
   {
     char *searchPtr = strstr(response, "+USOCTL:");
     if (searchPtr != NULL)
-      scanNum = sscanf(searchPtr, "+USOCTL: %d,0,%d",
+      scanNum = sscanf(searchPtr, "+USOCTL:%d,0,%d",
                         &socketStore, &paramVal);
     if (scanNum != 2)
     {
@@ -3327,7 +3327,7 @@ SARA_R5_error_t SARA_R5::querySocketLastError(int socket, int *error)
   {
     char *searchPtr = strstr(response, "+USOCTL:");
     if (searchPtr != NULL)
-      scanNum = sscanf(searchPtr, "+USOCTL: %d,1,%d",
+      scanNum = sscanf(searchPtr, "+USOCTL:%d,1,%d",
                         &socketStore, &paramVal);
     if (scanNum != 2)
     {
@@ -3378,7 +3378,7 @@ SARA_R5_error_t SARA_R5::querySocketTotalBytesSent(int socket, uint32_t *total)
   {
     char *searchPtr = strstr(response, "+USOCTL:");
     if (searchPtr != NULL)
-      scanNum = sscanf(searchPtr, "+USOCTL: %d,2,%lu",
+      scanNum = sscanf(searchPtr, "+USOCTL:^%d,2,%lu",
                         &socketStore, &paramVal);
     if (scanNum != 2)
     {
@@ -3429,7 +3429,7 @@ SARA_R5_error_t SARA_R5::querySocketTotalBytesReceived(int socket, uint32_t *tot
   {
     char *searchPtr = strstr(response, "+USOCTL:");
     if (searchPtr != NULL)
-      scanNum = sscanf(searchPtr, "+USOCTL: %d,3,%lu",
+      scanNum = sscanf(searchPtr, "+USOCTL:%d,3,%lu",
                         &socketStore, &paramVal);
     if (scanNum != 2)
     {
@@ -3480,7 +3480,7 @@ SARA_R5_error_t SARA_R5::querySocketRemoteIPAddress(int socket, IPAddress *addre
   {
     char *searchPtr = strstr(response, "+USOCTL:");
     if (searchPtr != NULL)
-      scanNum = sscanf(searchPtr, "+USOCTL: %d,4,\"%d.%d.%d.%d\",%d",
+      scanNum = sscanf(searchPtr, "+USOCTL:%d,4,\"%d.%d.%d.%d\",%d",
                         &socketStore,
                         &paramVals[0], &paramVals[1], &paramVals[2], &paramVals[3],
                         &paramVals[4]);
@@ -3536,7 +3536,7 @@ SARA_R5_error_t SARA_R5::querySocketStatusTCP(int socket, SARA_R5_tcp_socket_sta
   {
     char *searchPtr = strstr(response, "+USOCTL:");
     if (searchPtr != NULL)
-      scanNum = sscanf(searchPtr, "+USOCTL: %d,10,%d",
+      scanNum = sscanf(searchPtr, "+USOCTL:%d,10,%d",
                         &socketStore, &paramVal);
     if (scanNum != 2)
     {
@@ -3587,7 +3587,7 @@ SARA_R5_error_t SARA_R5::querySocketOutUnackData(int socket, uint32_t *total)
   {
     char *searchPtr = strstr(response, "+USOCTL:");
     if (searchPtr != NULL)
-      scanNum = sscanf(searchPtr, "+USOCTL: %d,11,%lu",
+      scanNum = sscanf(searchPtr, "+USOCTL:%d,11,%lu",
                         &socketStore, &paramVal);
     if (scanNum != 2)
     {
@@ -3638,7 +3638,7 @@ int SARA_R5::socketGetLastError()
   {
     char *searchPtr = strstr(response, "+USOER:");
     if (searchPtr != NULL)
-      sscanf(searchPtr, "+USOER: %d", &errorCode);
+      sscanf(searchPtr, "+USOER:%d", &errorCode);
   }
 
   free(command);
@@ -4454,7 +4454,7 @@ SARA_R5_error_t SARA_R5::getNetworkAssignedIPAddress(int profile, IPAddress *add
   {
     char *searchPtr = strstr(response, "+UPSND:");
     if (searchPtr != NULL)
-      scanNum = sscanf(searchPtr, "+UPSND: %d,%d,\"%d.%d.%d.%d\"",
+      scanNum = sscanf(searchPtr, "+UPSND:%d,%d,\"%d.%d.%d.%d\"",
                         &profileStore, &paramTag,
                         &paramVals[0], &paramVals[1], &paramVals[2], &paramVals[3]);
     if (scanNum != 6)
@@ -5104,7 +5104,7 @@ SARA_R5_error_t SARA_R5::getFileSize(String filename, int *size)
   }
 
   int fileSize;
-  sscanf(responseStart, "+ULSTFILE: %d", &fileSize);
+  sscanf(responseStart, "+ULSTFILE:%d", &fileSize);
   *size = fileSize;
 
   free(command);
@@ -5420,7 +5420,7 @@ SARA_R5_error_t SARA_R5::getMNOprofile(mobile_network_operator_t *mno)
   int scanned = 0;
   char *searchPtr = strstr(response, "+UMNOPROF:");
   if (searchPtr != NULL)
-    scanned = sscanf(searchPtr, "+UMNOPROF: %d,%d,%d,%d", &oStore, &d, &r, &u);
+    scanned = sscanf(searchPtr, "+UMNOPROF:%d,%d,%d,%d", &oStore, &d, &r, &u);
   o = (mobile_network_operator_t)oStore;
 
   if (scanned >= 1)
@@ -5830,7 +5830,9 @@ SARA_R5_error_t SARA_R5::parseSocketCloseIndication(String *closeIndication)
   int search;
   int socket;
 
-  search = closeIndication->indexOf("UUSOCL:") + strlen("UUSOCL:");
+  search = closeIndication->indexOf("UUSOCL:");
+  search += 7;
+  if (closeIndication->charAt(search) == ' ') search ++;
 
   // Socket will be first integer, should be single-digit number between 0-6:
   socket = closeIndication->substring(search, search + 1).toInt();

--- a/src/SparkFun_u-blox_SARA-R5_Arduino_Library.cpp
+++ b/src/SparkFun_u-blox_SARA-R5_Arduino_Library.cpp
@@ -5838,7 +5838,7 @@ SARA_R5_error_t SARA_R5::parseSocketCloseIndication(String *closeIndication)
 
   search = closeIndication->indexOf("UUSOCL:");
   search += 7;
-  if (closeIndication->charAt(search) == ' ') search ++;
+  while (closeIndication->charAt(search) == ' ') search ++; // skip spaces
 
   // Socket will be first integer, should be single-digit number between 0-6:
   socket = closeIndication->substring(search, search + 1).toInt();

--- a/src/SparkFun_u-blox_SARA-R5_Arduino_Library.cpp
+++ b/src/SparkFun_u-blox_SARA-R5_Arduino_Library.cpp
@@ -1123,9 +1123,12 @@ SARA_R5_error_t SARA_R5::clock(uint8_t *y, uint8_t *mo, uint8_t *d,
   if (err == SARA_R5_ERROR_SUCCESS)
   {
     char *searchPtr = strstr(response, "+CCLK:");
-    if (searchPtr != NULL)
-      scanNum = sscanf(searchPtr, "+CCLK:\"%d/%d/%d,%d:%d:%d%c%d\"\r\n",
+    if (searchPtr != NULL) {
+      searchPtr += 6; //  Move searchPtr to first char
+      while (*searchPtr == ' ') searchPtr++; // skip spaces
+      scanNum = sscanf(searchPtr, "\"%d/%d/%d,%d:%d:%d%c%d\"\r\n",
                &iy, &imo, &id, &ih, &imin, &is, &tzPlusMinus, &itz);
+    }
     if (scanNum == 8)
     {
       *y = iy;
@@ -1668,7 +1671,7 @@ SARA_R5_error_t SARA_R5::getAPN(int cid, String *apn, IPAddress *ip, SARA_R5_pdp
         char strApn[128];
         int ipOct[4];
 		
-        searchPtr += 6; // Point to the cid
+        searchPtr += 9; // Point to the cid
         scanned = sscanf(searchPtr, "%d,\"%[^\"]\",\"%[^\"]\",\"%d.%d.%d.%d",
         &rcid, strPdpType, strApn,
 				&ipOct[0], &ipOct[1], &ipOct[2], &ipOct[3]);
@@ -1730,8 +1733,11 @@ SARA_R5_error_t SARA_R5::getSimStatus(String* code)
     int scanned = 0;
     char c[16];
     char *searchPtr = strstr(response, "+CPIN:");
-    if (searchPtr != NULL)
-      scanned = sscanf(searchPtr, "+CPIN:%s\r\n", c);
+    if (searchPtr != NULL) {
+      searchPtr += 6; //  Move searchPtr to first char
+      while (*searchPtr == ' ') searchPtr++; // skip spaces
+      scanned = sscanf(searchPtr, "%s\r\n", c);
+    }
     if (scanned == 1)
     {
       if(code)
@@ -3378,7 +3384,7 @@ SARA_R5_error_t SARA_R5::querySocketTotalBytesSent(int socket, uint32_t *total)
   {
     char *searchPtr = strstr(response, "+USOCTL:");
     if (searchPtr != NULL)
-      scanNum = sscanf(searchPtr, "+USOCTL:^%d,2,%lu",
+      scanNum = sscanf(searchPtr, "+USOCTL:%d,2,%lu",
                         &socketStore, &paramVal);
     if (scanNum != 2)
     {

--- a/src/SparkFun_u-blox_SARA-R5_Arduino_Library.cpp
+++ b/src/SparkFun_u-blox_SARA-R5_Arduino_Library.cpp
@@ -1122,7 +1122,7 @@ SARA_R5_error_t SARA_R5::clock(uint8_t *y, uint8_t *mo, uint8_t *d,
   // Response format (if TZ is negative): \r\n+CCLK: "YY/MM/DD,HH:MM:SS-TZ"\r\n\r\nOK\r\n
   if (err == SARA_R5_ERROR_SUCCESS)
   {
-    char *searchPtr = strstr(response, "+CCLK: ");
+    char *searchPtr = strstr(response, "+CCLK:");
     if (searchPtr != NULL)
       scanNum = sscanf(searchPtr, "+CCLK: \"%d/%d/%d,%d:%d:%d%c%d\"\r\n",
                &iy, &imo, &id, &ih, &imin, &is, &tzPlusMinus, &itz);
@@ -1257,7 +1257,7 @@ SARA_R5_error_t SARA_R5::getUtimeMode(SARA_R5_utime_mode_t *mode, SARA_R5_utime_
   if (err == SARA_R5_ERROR_SUCCESS)
   {
     int mStore, sStore, scanned = 0;
-    char *searchPtr = strstr(response, "+UTIME: ");
+    char *searchPtr = strstr(response, "+UTIME:");
     if (searchPtr != NULL)
       scanned = sscanf(searchPtr, "+UTIME: %d,%d\r\n", &mStore, &sStore);
     m = (SARA_R5_utime_mode_t)mStore;
@@ -1324,7 +1324,7 @@ SARA_R5_error_t SARA_R5::getUtimeIndication(SARA_R5_utime_urc_configuration_t *c
   if (err == SARA_R5_ERROR_SUCCESS)
   {
     int cStore, scanned = 0;
-    char *searchPtr = strstr(response, "+UTIMEIND: ");
+    char *searchPtr = strstr(response, "+UTIMEIND:");
     if (searchPtr != NULL)
       scanned = sscanf(searchPtr, "+UTIMEIND: %d\r\n", &cStore);
     c = (SARA_R5_utime_urc_configuration_t)cStore;
@@ -1389,7 +1389,7 @@ SARA_R5_error_t SARA_R5::getUtimeConfiguration(int32_t *offsetNanoseconds, int32
   if (err == SARA_R5_ERROR_SUCCESS)
   {
     int scanned = 0;
-    char *searchPtr = strstr(response, "+UTIMECFG: ");
+    char *searchPtr = strstr(response, "+UTIMECFG:");
     if (searchPtr != NULL)
 #if defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_ESP8266)
       scanned = sscanf(searchPtr, "+UTIMECFG: %d,%d\r\n", &ons, &os);
@@ -1456,7 +1456,7 @@ int8_t SARA_R5::rssi(void)
   }
 
   int scanned = 0;
-  char *searchPtr = strstr(response, "+CSQ: ");
+  char *searchPtr = strstr(response, "+CSQ:");
   if (searchPtr != NULL)
     scanned = sscanf(searchPtr, "+CSQ: %d,%*d", &rssi);
   if (scanned != 1)
@@ -1499,7 +1499,7 @@ SARA_R5_registration_status_t SARA_R5::registration(bool eps)
   }
   
   int scanned = 0;
-  const char *startTag = eps ? "+CEREG: " : "+CREG: ";
+  const char *startTag = eps ? "+CEREG:" : "+CREG:";
   char *searchPtr = strstr(response, startTag);
   if (searchPtr != NULL) {
 	  const char *format = eps ? "+CEREG: %*d,%d" : "+CREG: %*d,%d";
@@ -1661,14 +1661,14 @@ SARA_R5_error_t SARA_R5::getAPN(int cid, String *apn, IPAddress *ip, SARA_R5_pdp
     {
       int scanned = 0;
       // Find the first/next occurrence of +CGDCONT:
-      searchPtr = strstr(searchPtr, "+CGDCONT: ");
+      searchPtr = strstr(searchPtr, "+CGDCONT:");
       if (searchPtr != NULL)
       {
         char strPdpType[10];
         char strApn[128];
         int ipOct[4];
 		
-        searchPtr += strlen("+CGDCONT: "); // Point to the cid
+        searchPtr += strlen("+CGDCONT:"); // Point to the cid
         scanned = sscanf(searchPtr, "%d,\"%[^\"]\",\"%[^\"]\",\"%d.%d.%d.%d",
         &rcid, strPdpType, strApn,
 				&ipOct[0], &ipOct[1], &ipOct[2], &ipOct[3]);
@@ -1729,7 +1729,7 @@ SARA_R5_error_t SARA_R5::getSimStatus(String* code)
   {
     int scanned = 0;
     char c[16];
-    char *searchPtr = strstr(response, "+CPIN: ");
+    char *searchPtr = strstr(response, "+CPIN:");
     if (searchPtr != NULL)
       scanned = sscanf(searchPtr, "+CPIN: %s\r\n", c);
     if (scanned == 1)
@@ -1803,7 +1803,7 @@ SARA_R5_error_t SARA_R5::getSIMstateReportingMode(int *mode)
   if (err == SARA_R5_ERROR_SUCCESS)
   {
     int scanned = 0;
-    char *searchPtr = strstr(response, "+USIMSTAT: ");
+    char *searchPtr = strstr(response, "+USIMSTAT:");
     if (searchPtr != NULL)
       scanned = sscanf(searchPtr, "+USIMSTAT: %d\r\n", &m);
     if (scanned == 1)
@@ -2005,10 +2005,11 @@ SARA_R5_error_t SARA_R5::getOperator(String *oper)
 
   if (err == SARA_R5_ERROR_SUCCESS)
   {
-    searchPtr = strstr(response, "+COPS: ");
+    searchPtr = strstr(response, "+COPS:");
     if (searchPtr != NULL)
     {
-      searchPtr += strlen("+COPS: "); //  Move searchPtr to first char
+      searchPtr += 6; //  Move searchPtr to first char
+      while (*searchPtr == ' ') searchPtr++; // skip spaces
       mode = *searchPtr;              // Read first char -- should be mode
       if (mode == '2')                // Check for de-register
       {
@@ -2157,7 +2158,7 @@ SARA_R5_error_t SARA_R5::getPreferredMessageStorage(int *used, int *total, Strin
   }
 
   int scanned = 0;
-  char *searchPtr = strstr(response, "+CPMS: ");
+  char *searchPtr = strstr(response, "+CPMS:");
   if (searchPtr != NULL)
     scanned = sscanf(searchPtr, "+CPMS: %d,%d", &u, &t);
   if (scanned == 2)
@@ -2209,11 +2210,12 @@ SARA_R5_error_t SARA_R5::readSMSmessage(int location, String *unread, String *fr
   {
     char *searchPtr = response;
 
-    // Find the first occurrence of +CGDCONT:
-    searchPtr = strstr(searchPtr, "+CMGR: ");
+    // Find the first occurrence of +CMGR:
+    searchPtr = strstr(searchPtr, "+CMGR:");
     if (searchPtr != NULL)
     {
-      searchPtr += strlen("+CMGR: "); // Point to the originator address
+      searchPtr += 6; //  Move searchPtr to first char
+      while (*searchPtr == ' ') searchPtr++; // skip spaces
       int pointer = 0;
       while ((*(++searchPtr) != '\"') && (*searchPtr != '\0') && (pointer < 12))
       {
@@ -2759,7 +2761,7 @@ SARA_R5_error_t SARA_R5::socketRead(int socket, int length, char *readDest, int 
     }
 
     // Extract the data
-    char *searchPtr = strstr(response, "+USORD: ");
+    char *searchPtr = strstr(response, "+USORD:");
     if (searchPtr != NULL)
       scanNum = sscanf(searchPtr, "+USORD: %d,%d",
                         &socketStore, &readLength);
@@ -2872,7 +2874,7 @@ SARA_R5_error_t SARA_R5::socketReadAvailable(int socket, int *length)
 
   if (err == SARA_R5_ERROR_SUCCESS)
   {
-    char *searchPtr = strstr(response, "+USORD: ");
+    char *searchPtr = strstr(response, "+USORD:");
     if (searchPtr != NULL)
       scanNum = sscanf(searchPtr, "+USORD: %d,%d",
                         &socketStore, &readLength);
@@ -2969,7 +2971,7 @@ SARA_R5_error_t SARA_R5::socketReadUDP(int socket, int length, char *readDest,
     }
 
     // Extract the data
-    char *searchPtr = strstr(response, "+USORF: ");
+    char *searchPtr = strstr(response, "+USORF:");
     if (searchPtr != NULL)
       scanNum = sscanf(searchPtr, "+USORF: %d,\"%d.%d.%d.%d\",%d,%d",
                         &socketStore, &remoteIPstore[0], &remoteIPstore[1], &remoteIPstore[2], &remoteIPstore[3],
@@ -3102,7 +3104,7 @@ SARA_R5_error_t SARA_R5::socketReadAvailableUDP(int socket, int *length)
 
   if (err == SARA_R5_ERROR_SUCCESS)
   {
-    char *searchPtr = strstr(response, "+USORF: ");
+    char *searchPtr = strstr(response, "+USORF:");
     if (searchPtr != NULL)
       scanNum = sscanf(searchPtr, "+USORF: %d,%d",
                         &socketStore, &readLength);
@@ -3271,7 +3273,7 @@ SARA_R5_error_t SARA_R5::querySocketType(int socket, SARA_R5_socket_protocol_t *
 
   if (err == SARA_R5_ERROR_SUCCESS)
   {
-    char *searchPtr = strstr(response, "+USOCTL: ");
+    char *searchPtr = strstr(response, "+USOCTL:");
     if (searchPtr != NULL)
       scanNum = sscanf(searchPtr, "+USOCTL: %d,0,%d",
                         &socketStore, &paramVal);
@@ -3323,7 +3325,7 @@ SARA_R5_error_t SARA_R5::querySocketLastError(int socket, int *error)
 
   if (err == SARA_R5_ERROR_SUCCESS)
   {
-    char *searchPtr = strstr(response, "+USOCTL: ");
+    char *searchPtr = strstr(response, "+USOCTL:");
     if (searchPtr != NULL)
       scanNum = sscanf(searchPtr, "+USOCTL: %d,1,%d",
                         &socketStore, &paramVal);
@@ -3374,7 +3376,7 @@ SARA_R5_error_t SARA_R5::querySocketTotalBytesSent(int socket, uint32_t *total)
 
   if (err == SARA_R5_ERROR_SUCCESS)
   {
-    char *searchPtr = strstr(response, "+USOCTL: ");
+    char *searchPtr = strstr(response, "+USOCTL:");
     if (searchPtr != NULL)
       scanNum = sscanf(searchPtr, "+USOCTL: %d,2,%lu",
                         &socketStore, &paramVal);
@@ -3425,7 +3427,7 @@ SARA_R5_error_t SARA_R5::querySocketTotalBytesReceived(int socket, uint32_t *tot
 
   if (err == SARA_R5_ERROR_SUCCESS)
   {
-    char *searchPtr = strstr(response, "+USOCTL: ");
+    char *searchPtr = strstr(response, "+USOCTL:");
     if (searchPtr != NULL)
       scanNum = sscanf(searchPtr, "+USOCTL: %d,3,%lu",
                         &socketStore, &paramVal);
@@ -3476,7 +3478,7 @@ SARA_R5_error_t SARA_R5::querySocketRemoteIPAddress(int socket, IPAddress *addre
 
   if (err == SARA_R5_ERROR_SUCCESS)
   {
-    char *searchPtr = strstr(response, "+USOCTL: ");
+    char *searchPtr = strstr(response, "+USOCTL:");
     if (searchPtr != NULL)
       scanNum = sscanf(searchPtr, "+USOCTL: %d,4,\"%d.%d.%d.%d\",%d",
                         &socketStore,
@@ -3532,7 +3534,7 @@ SARA_R5_error_t SARA_R5::querySocketStatusTCP(int socket, SARA_R5_tcp_socket_sta
 
   if (err == SARA_R5_ERROR_SUCCESS)
   {
-    char *searchPtr = strstr(response, "+USOCTL: ");
+    char *searchPtr = strstr(response, "+USOCTL:");
     if (searchPtr != NULL)
       scanNum = sscanf(searchPtr, "+USOCTL: %d,10,%d",
                         &socketStore, &paramVal);
@@ -3583,7 +3585,7 @@ SARA_R5_error_t SARA_R5::querySocketOutUnackData(int socket, uint32_t *total)
 
   if (err == SARA_R5_ERROR_SUCCESS)
   {
-    char *searchPtr = strstr(response, "+USOCTL: ");
+    char *searchPtr = strstr(response, "+USOCTL:");
     if (searchPtr != NULL)
       scanNum = sscanf(searchPtr, "+USOCTL: %d,11,%lu",
                         &socketStore, &paramVal);
@@ -3634,7 +3636,7 @@ int SARA_R5::socketGetLastError()
 
   if (err == SARA_R5_ERROR_SUCCESS)
   {
-    char *searchPtr = strstr(response, "+USOER: ");
+    char *searchPtr = strstr(response, "+USOER:");
     if (searchPtr != NULL)
       sscanf(searchPtr, "+USOER: %d", &errorCode);
   }
@@ -4450,7 +4452,7 @@ SARA_R5_error_t SARA_R5::getNetworkAssignedIPAddress(int profile, IPAddress *add
 
   if (err == SARA_R5_ERROR_SUCCESS)
   {
-    char *searchPtr = strstr(response, "+UPSND: ");
+    char *searchPtr = strstr(response, "+UPSND:");
     if (searchPtr != NULL)
       scanNum = sscanf(searchPtr, "+UPSND: %d,%d,\"%d.%d.%d.%d\"",
                         &profileStore, &paramTag,
@@ -4872,7 +4874,7 @@ SARA_R5_error_t SARA_R5::getFileContents(String filename, String *contents)
   // Response format: \r\n+URDFILE: "filename",36,"these bytes are the data of the file"\r\n\r\nOK\r\n
   int scanned = 0;
   int readFileSize = 0;
-  char *searchPtr = strstr(response, "+URDFILE: ");
+  char *searchPtr = strstr(response, "+URDFILE:");
   if (searchPtr != NULL)
   {
     searchPtr = strchr(searchPtr, '\"'); // Find the first quote
@@ -4994,7 +4996,7 @@ SARA_R5_error_t SARA_R5::getFileContents(String filename, char *contents)
   // Response format: \r\n+URDFILE: "filename",36,"these bytes are the data of the file"\r\n\r\nOK\r\n
   int scanned = 0;
   int readFileSize = 0;
-  char *searchPtr = strstr(response, "+URDFILE: ");
+  char *searchPtr = strstr(response, "+URDFILE:");
   if (searchPtr != NULL)
   {
     searchPtr = strchr(searchPtr, '\"'); // Find the first quote
@@ -5087,7 +5089,7 @@ SARA_R5_error_t SARA_R5::getFileSize(String filename, int *size)
     return err;
   }
 
-  char *responseStart = strstr(response, "+ULSTFILE: ");
+  char *responseStart = strstr(response, "+ULSTFILE:");
   if (responseStart == NULL)
   {
     if (_printDebug == true)
@@ -5416,7 +5418,7 @@ SARA_R5_error_t SARA_R5::getMNOprofile(mobile_network_operator_t *mno)
   }
 
   int scanned = 0;
-  char *searchPtr = strstr(response, "+UMNOPROF: ");
+  char *searchPtr = strstr(response, "+UMNOPROF:");
   if (searchPtr != NULL)
     scanned = sscanf(searchPtr, "+UMNOPROF: %d,%d,%d,%d", &oStore, &d, &r, &u);
   o = (mobile_network_operator_t)oStore;
@@ -5828,7 +5830,7 @@ SARA_R5_error_t SARA_R5::parseSocketCloseIndication(String *closeIndication)
   int search;
   int socket;
 
-  search = closeIndication->indexOf("UUSOCL: ") + strlen("UUSOCL: ");
+  search = closeIndication->indexOf("UUSOCL:") + strlen("UUSOCL:");
 
   // Socket will be first integer, should be single-digit number between 0-6:
   socket = closeIndication->substring(search, search + 1).toInt();


### PR DESCRIPTION
Hi @PaulZC, 

This is an attempt to make the AT parser more tolerant to spaces following the first `:` in URCs and responses.

In the past it searched for `+CREG: <data>` this is correct for many modems. but some variants of modems (like LENA-R8 in ES stage) do not strictly follow that format and sometimes omit the space ` ` between the `:` and the `<data>` following. this pull request tries to make the parser in this library more tolerant. The changes in the code involves searching for a shorter response code only until `:`and the either skip the spaces of let the `%d` in the following `scanf` handle that. 

I must admit I have not tested with all the different examples or modems. But my code uses quite many commands and APIs already. I leave it up to you if you think this is useful for everybody. Maybe it would be good to give it a review from your side. 