### PR TITLE
v1.1.8

### DIFF
--- a/examples/SARA-R5_Example4_RegisterOperator/SARA-R5_Example4_RegisterOperator.ino
+++ b/examples/SARA-R5_Example4_RegisterOperator/SARA-R5_Example4_RegisterOperator.ino
@@ -349,11 +349,20 @@ void printOperators(struct operator_stats * ops, int operatorsAvailable)
     }
     switch (ops[i].act)
     {
-    // SARA-R5 only supports LTE
+    case 0:
+      Serial.print(F(" - GSM"));
+      break;
+    case 2:
+      Serial.print(F(" - UTRAN"));
+      break;
+    case 3:
+      Serial.print(F(" - GSM/GPRS with EDGE"));
+      break;
     case 7:
-      Serial.print(F(" - LTE"));
+      Serial.print(F(" - LTE")); // SARA-R5 only supports LTE
       break;
     }
+    Serial.println();
   }
   Serial.println();
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SparkFun u-blox SARA-R5 Arduino Library
-version=1.1.7
+version=1.1.8
 author=SparkFun Electronics <techsupport@sparkfun.com>
 maintainer=SparkFun Electronics <sparkfun.com>
 sentence=Library for the u-blox SARA-R5 LTE-M / NB-IoT modules with secure cloud<br/><br/>

--- a/src/SparkFun_u-blox_SARA-R5_Arduino_Library.h
+++ b/src/SparkFun_u-blox_SARA-R5_Arduino_Library.h
@@ -1024,7 +1024,7 @@ public:
   SARA_R5_error_t sendCustomCommandWithResponse(const char *command, const char *expectedResponse,
                                                 char *responseDest, unsigned long commandTimeout = SARA_R5_STANDARD_RESPONSE_TIMEOUT, bool at = true);
 
-private:
+protected:
   HardwareSerial *_hardSerial;
 #ifdef SARA_R5_SOFTWARE_SERIAL_ENABLED
   SoftwareSerial *_softSerial;


### PR DESCRIPTION
This release:
* Updates Example4 with additional Access Technologies for the LARA-R6
* Changes the ```private``` methods and variables to ```protected```
  * This makes it _much_ easier to derive your own class for (e.g.) the LARA-R6 and reuse methods like ```sendCommandWithResponse```