### PR TITLE
Add option to enable TLS security on a socket

### DIFF
--- a/src/SparkFun_u-blox_SARA-R5_Arduino_Library.cpp
+++ b/src/SparkFun_u-blox_SARA-R5_Arduino_Library.cpp
@@ -2705,6 +2705,20 @@ int SARA_R5::socketOpen(SARA_R5_socket_protocol_t protocol, unsigned int localPo
   return sockId;
 }
 
+$SARA_R5_error_t SARA_R5::socketSetSecure(int profile, bool secure, int secprofile)
+{
+  SARA_R5_error_t err;
+  char *command = sara_r5_calloc_char(strlen(SARA_R5_SECURE_SOCKET) + 32);
+  if (command == nullptr)
+    return SARA_R5_ERROR_OUT_OF_MEMORY;
+  if ((secprofile == -1) || !secure) sprintf(command, "%s=%d,%d", SARA_R5_SECURE_SOCKET, profile, secure);
+  else sprintf(command, "%s=%d,%d,%d", SARA_R5_SECURE_SOCKET, profile, secure, secprofile);
+  err = sendCommandWithResponse(command, SARA_R5_RESPONSE_OK_OR_ERROR, nullptr,
+                                SARA_R5_STANDARD_RESPONSE_TIMEOUT);
+  free(command);
+  return err;
+}
+
 SARA_R5_error_t SARA_R5::socketClose(int socket, unsigned long timeout)
 {
   SARA_R5_error_t err;
@@ -4089,7 +4103,7 @@ SARA_R5_error_t SARA_R5::setHTTPsecure(int profile, bool secure, int secprofile)
   command = sara_r5_calloc_char(strlen(SARA_R5_HTTP_PROFILE) + 32);
   if (command == nullptr)
     return SARA_R5_ERROR_OUT_OF_MEMORY;
-  if (secprofile == -1)
+  if ((secprofile == -1) || !secure) 
       sprintf(command, "%s=%d,%d,%d", SARA_R5_HTTP_PROFILE, profile, SARA_R5_HTTP_OP_CODE_SECURE,
           secure);
   else sprintf(command, "%s=%d,%d,%d,%d", SARA_R5_HTTP_PROFILE, profile, SARA_R5_HTTP_OP_CODE_SECURE,
@@ -4302,7 +4316,7 @@ SARA_R5_error_t SARA_R5::setMQTTsecure(bool secure, int secprofile)
     command = sara_r5_calloc_char(strlen(SARA_R5_MQTT_PROFILE) + 16);
     if (command == nullptr)
       return SARA_R5_ERROR_OUT_OF_MEMORY;
-    if (secprofile == -1) sprintf(command, "%s=%d,%d", SARA_R5_MQTT_PROFILE, SARA_R5_MQTT_PROFILE_SECURE, secure);
+    if ((secprofile == -1) || !secure) sprintf(command, "%s=%d,%d", SARA_R5_MQTT_PROFILE, SARA_R5_MQTT_PROFILE_SECURE, secure);
     else sprintf(command, "%s=%d,%d,%d", SARA_R5_MQTT_PROFILE, SARA_R5_MQTT_PROFILE_SECURE, secure, secprofile);
     err = sendCommandWithResponse(command, SARA_R5_RESPONSE_OK_OR_ERROR, nullptr,
                                   SARA_R5_STANDARD_RESPONSE_TIMEOUT);

--- a/src/SparkFun_u-blox_SARA-R5_Arduino_Library.h
+++ b/src/SparkFun_u-blox_SARA-R5_Arduino_Library.h
@@ -153,6 +153,7 @@ const char SARA_R5_GET_ERROR[] = "+USOER";          // Get last socket error.
 const char SARA_R5_SOCKET_DIRECT_LINK[] = "+USODL"; // Set socket in Direct Link mode
 const char SARA_R5_SOCKET_CONTROL[] = "+USOCTL";    // Query the socket parameters
 const char SARA_R5_UD_CONFIGURATION[] = "+UDCONF";  // User Datagram Configuration
+const char SARA_R5_SECURE_SOCKET[] = "+USOSEC";     // SSL/TLS/DTLS mode configuration
 // ### Ping
 const char SARA_R5_PING_COMMAND[] = "+UPING"; // Ping
 // ### HTTP
@@ -897,6 +898,8 @@ public:
   SARA_R5_error_t querySocketRemoteIPAddress(int socket, IPAddress *address, int *port);
   SARA_R5_error_t querySocketStatusTCP(int socket, SARA_R5_tcp_socket_status_t *status);
   SARA_R5_error_t querySocketOutUnackData(int socket, uint32_t *total);
+  // enable / disable socket securoty 
+  SARA_R5_error_t socketSetSecure(int profile, bool secure, int secprofile = -1);
   // Return the most recent socket error
   int socketGetLastError();
   // Return the remote IP Address from the most recent socket listen indication (socket connection)


### PR DESCRIPTION
- Added socketSetSecure API for +USOSEC AT command 
- All setSecure APIs (HTTP,MQTT,Socket) when security is disabled then security profile should not be set

An example use of this api is available in the NTRIP client implementation of the HPG solution here: 
https://github.com/mazgch/hpg/blob/3e2fcff08202953c9d181b1cce7e8f603e47db38/software/LTE.h#L476